### PR TITLE
[BUGFIX] Add missing information in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,14 @@
 		"psr-4": {
 			"LMS\\Routes\\Tests\\": "Tests"
 		}
+	},
+	"extra": {
+		"typo3/cms": {
+			"extension-key": "routes"
+		}
+	},
+	"replace": {
+		"lms/routes": "self.version",
+		"typo3-ter/routes": "self.version"
 	}
 }


### PR DESCRIPTION
This PR will add missing information in `composer.json`, such as specifying the extension key.