### PR TITLE
- added condition to YamlFileLoader.php to prevent PHP 8.* warnings 

### DIFF
--- a/Classes/Loader/YamlFileLoader.php
+++ b/Classes/Loader/YamlFileLoader.php
@@ -56,7 +56,11 @@ class YamlFileLoader extends SymfonyLoader
     {
         $yml = $this->retrievePathFor($file . '.yml');
         $yaml = $this->retrievePathFor($file . '.yaml');
-        $custom = (array)$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['routes']['additionalPathList'];
+        if (array_key_exists("additionalPathList", $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['routes'])) {
+            $custom = (array)$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['routes']['additionalPathList'];
+        } else {
+            $custom = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['routes']['additionalPathList'] = [];
+        }
 
         return array_merge($yml, $yaml, $custom);
     }


### PR DESCRIPTION
In TYPO3 11 running on PHP v8.* the YamlFileLoader is throwing constantly a PHP warning, in line 59 because the array key $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['routes']['additionalPathList'] does not exists initially.  