### PR TITLE
Make it possibility to overwrite the prefix *api* and do not ignore the site base path

### DIFF
--- a/Classes/Routing/RestApiEnhancer.php
+++ b/Classes/Routing/RestApiEnhancer.php
@@ -44,7 +44,8 @@ class RestApiEnhancer extends PluginEnhancer
     {
         $defaultOptions = $collection->get('default')->getOptions();
 
-        $apiRoute = new Route('/api/{any}', [], ['any' => '.*'], $defaultOptions);
+		$pathPrefix = empty($this->configuration['pathPrefix']) ? '/api/' : ('/' . trim($this->configuration['pathPrefix'], '/') . '/');
+        $apiRoute = new Route($pathPrefix . '{any}', [], ['any' => '.*'], $defaultOptions);
 
         $collection->add('api', $apiRoute);
     }


### PR DESCRIPTION
# Issue
### Problem 1
Routing slugs are treated as absolute paths and not relative to the site configuration URL.
Consider the following example
	* base URL in the TYPO3 site config: *http://localhost:7080/rest*
	* path of a route in ext/Configuration/Routes.yml: *api/v1/login*
	
Requesting just *http://localhost:7080/api/v1/login* will not work since TYPO3 would not be able to find the site configuration (`TYPO3\CMS\Frontend\Middleware\SiteResolver`).
On the other hand requesting *http://localhost:7080/rest/api/v1/login* will lead to the problem that `LMS\Routes\Extbase\RouteHandler` will not be able to match the route, since it tries to match the entire requested path (*rest/api/v1/login*) and not only the path below the site base path (*rest*), which would only be (*api/v1/login*).

### Problem 2
The prefix *api* of the route path is hardcoded in `LMS\Routes\Routing\RestApiEnhancer`. Therefore, all routes in any *Routes.yml* that does not start with *api/* will never work.


# Improvements in this Patch
This patch adds the possibility to overwrite the prefix *api* of the route path in `LMS\Routes\Routing\RestApiEnhancer` with the routeEnhancers configuration *pathPrefix*. This, makes it possible to configure routes in a *Routes.yml*, that do not need to beginn with *api/*.
Furthermore, the site base path is taken into account wen matching routes in the `LMS\Routes\Extbase\RouteHandler`. This makes it possible to use this extension on sites that does not have an empty site base path in the  TYPO3 site config (e.g. *http://localhost:7080/rest*)

Possible sample configuration:
* Endpoint: http://localhost:7080/rest/pos/api/v1/login
* TYPO3 site config example:
    ```
    base: 'http://localhost:7080/rest'
    routeEnhancers:
        ApplyRoutesCollection:
            type: Routes
            # added functionality:
            pathPrefix: 'pos/api'
    ```
* Routes.yml example:
   ```
    api_access-login:
        # path does not need to start with api anymore
        path: pos/api/v1/login
        controller: VENDOR\myext\Controller\AccessController::login
        methods: [POST]
        format: json
        defaults:
            vendor: VENDOR
            extension: myext
            plugin: Api
    ````