### PR TITLE
[BUGFIX] find configuration YAML if not in composer mode

### DIFF
--- a/Classes/Loader/Yaml.php
+++ b/Classes/Loader/Yaml.php
@@ -59,7 +59,11 @@ class Yaml
      */
     private function getPossiblePaths(): array
     {
-        $customExtensionsFolderPath = Environment::getComposerRootPath() . '/vendor/*/*/Configuration';
+        if (Environment::isComposerMode()) {
+            $customExtensionsFolderPath = Environment::getProjectPath() . '/vendor/*/*/Configuration';
+        } else {
+            $customExtensionsFolderPath = Environment::getExtensionsPath() . '/*/Configuration';
+        }
 
         $finder = new Finder();
         $result = $finder->in($customExtensionsFolderPath)->name('Routes.yaml');


### PR DESCRIPTION
An exception \BadMethodCallException "Composer root path is only available in Composer mode" pops up if in FunctionalTest environment using TYPO3 12 

Use Environment::getProjectRootPath() instead of internal method getComposerRootPath

We still assume that in composer-mode the extensions are to be found under /vendor/
