### PR TITLE
[BUGFIX] Fix array to string conversion causing php warnings

### DIFF
--- a/Classes/Extbase/RouteHandler.php
+++ b/Classes/Extbase/RouteHandler.php
@@ -161,7 +161,7 @@ class RouteHandler
 
         if (ServerRequest::isFormSubmit()) {
             foreach (ServerRequest::formBody() as $name => $value) {
-                ServerRequest::withParameter($name, (string)$value, $plugin);
+                ServerRequest::withParameter($name, is_array($value) ? $value : (string)$value, $plugin);
             }
         }
     }


### PR DESCRIPTION
Fix array to string conversion causing php warnings for requests having content-type: x-www-form-urlencode.